### PR TITLE
WIP: Add reference-docs about storage configs

### DIFF
--- a/reference-docs/server-configuration/config.md
+++ b/reference-docs/server-configuration/config.md
@@ -239,6 +239,8 @@ designLoader: {
 Configure the Livingdocs Design Server. When a design is uploaded the assets
 are moved to the storage configured here.
 
+For details about the `storage` option see [storage-config](./file-storage-config.md)
+
 ```js
 designs: {
   assets: {
@@ -333,7 +335,7 @@ files: {
 ```js
 documents: {
   imageServices: {
-    imgix: {} // imageService specific configuration 
+    imgix: {} // imageService specific configuration
   }
 }
 ```

--- a/reference-docs/server-configuration/file-storage-config.md
+++ b/reference-docs/server-configuration/file-storage-config.md
@@ -1,0 +1,56 @@
+# Storage Configuration
+
+Multiple features need to store static files. For this they offer a `storage`
+option that allows for different storage strategies.
+
+
+## Amazon S3 strategy
+
+Example Amazon S3 configuration to store images:
+```js
+images: {
+  storage: {
+    strategy: 's3',
+    config: {
+      bucket: 'livingdocs-images-dev',
+      region: 'us-west-1',
+      accessKeyId: process.env.ENV_VAR,
+      secretAccessKey: process.env.ENV_VAR,
+    }
+  }
+}
+```
+
+
+#### Using a proxy with S3
+
+For S3 it is necessary to use the proxy-agent module. For more info see
+the [Amazon instructions](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-configuring-proxies.html)
+
+Warning: This only works if the environment variable `HTTP_PROXY` is not set.
+
+Example design asset configuration with a proxy:
+```js
+const proxy = require('proxy-agent')
+
+module.exports = {
+designs: {
+  assets: {
+    publicUrl: 'https://some-host.com',
+    storage: {
+      strategy: 's3',
+      config: {
+        bucket: 's3-bucket',
+        region: 'eu-central-1',
+        accessKeyId: process.env.ENV_VAR,
+        secretAccessKey: process.env.ENV_VAR,
+        signatureVersion: 'v4',
+        httpOptions: {
+          agent: proxy('http://proxy.some-host.com:3128/')
+        }
+      }
+    }
+  }
+  // ...
+}
+```

--- a/setup-and-deployment/proxy.md
+++ b/setup-and-deployment/proxy.md
@@ -1,10 +1,17 @@
 ## Running Livingdocs behind a proxy
 
-Where applicable, Livingdocs respects the environment variables `HTTPS_PROXY` and `HTTP_PROXY` by default and routes all external requests through the given proxy. 
+Where applicable, Livingdocs respects the environment variables `HTTPS_PROXY` and `HTTP_PROXY` by default and routes all external requests through the given proxy.
 
 ```
 HTTPS_PROXY=https://my.proxy.com
 HTTP_PROXY=http://my.proxy.com
 ```
 
-For more fine-grained control, you can adapt the proxy settings of each external service in your configuration file. 
+For more fine-grained control, you can adapt the proxy settings of each external service in your configuration file.
+
+
+## Feature configurations influenced by proxy settings
+
+If external storage is configured for features like `images` or `files` those sometimes need special configurations to work with a proxy.
+
+For details see [file-storage-config](../reference-docs/server-configuration/file-storage-config.md)


### PR DESCRIPTION
Document the `storage` option available in features that store static files. And document how S3 can be configured with a proxy.

## Todo

- Check if it is a problem if a user sets `httpOptions.agent` in a `storage` config and also the environment variable `HTTP_PROXY` (in which case `httpOptions.proxy` will be set as well).
https://github.com/upfrontIO/livingdocs-server/blame/validate-image-service-config-master/lib/blob-store/strategies/s3.js#L9
- Check if we can find a solution where customers who use a proxy must not require `proxy-agent` in their configuration (this can prevent customers from using JSON files for their configuration). 
- Update the server config reference-docs so that all features that can use the storage config mention it properly