### PR TITLE
Add disableEditTitleAtToolbar flag to the content-type config

### DIFF
--- a/reference-docs/server-configuration/content-type-config.md
+++ b/reference-docs/server-configuration/content-type-config.md
@@ -65,6 +65,8 @@ We plan to allow to move all layout options which are currently defined in the d
       // flag whether the component list in the sidebar should show icons and
       // desriptions (true) or only the titles (false)
       useExpandedComponentStyle: true
+      // flag whether the document title at the toolbar can be edited
+      disableEditTitleAtToolbar: false
     },
 
     frontend: {


### PR DESCRIPTION
Related:
- https://github.com/livingdocsIO/livingdocs-server/pull/2140
- https://github.com/livingdocsIO/livingdocs-editor/pull/2370