### PR TITLE
WIP: Improve the glossary

### DIFF
--- a/DICTIONARY.md
+++ b/DICTIONARY.md
@@ -20,6 +20,10 @@ The editor is an Angular web application. It is the user interface implementatio
 ## Livingdocs-...-boilerplate
 Our boilerplates are recipes to quickly get one started with a custom downstream implementation of our core products such as the editor or server.
 
+## Livingdocs SDK
+Our [SDK](https://github.com/livingdocsIO/livingdocs-node-sdk) is a helper library that wraps some of the livingdocs core functionality. 
+It is used for example to render documents, retrieve designs or changing document output.
+
 ## Upstream && Downstream
 *Upstream* is a package/repository which is integrated in another project called
 *downstream*. In our case the *upstreams* are our core `livingdocs-editor` and
@@ -45,3 +49,13 @@ our Print Api to print publishing systems like `NewsNT` or `WoodWing`.
 
 ## NewsNT
 A print publishing system.
+
+## Include / Doc-include
+Includes are our implementation of ESI's. (Edge side includes)
+The basic concept is that you set a placeholder in the livingdocs-design.
+Then in the server the way it will be rendered can be defined.
+You can also define assets (css, javascript) that will be only loaded once an include resolved.
+
+## Public api
+The [PublicApi](https://edit.livingdocs.io/public-api.html) exposes server endpoints which then can be consumed by a delivery (frontend).
+

--- a/DICTIONARY.md
+++ b/DICTIONARY.md
@@ -1,44 +1,47 @@
-
-## Channel
-
-Represents a collection of documents. All documents in a `channel` must use
-the same `design`. A `channel` also defines the `Renditions`.
-
-## Design
-
-A list of `Components` and configurations how they can be used
-in a `Livingdoc` and how users can interact with these `Components` in the
-`Livingdocs Editor`.
-
-## Downstream
-
-See *Upstream*.
-
-## [HuGO](http://www.sternwald.com/hugo/)
-
-A Digital Assets Management product developed and maintained by Sternwald, used
-to manage images and agency reports in large numbers. Also acts as a proxy for
-our Print Api to print publishing systems like `NewsNT` or `WoodWing`.
-
 ## Livingdoc
-
 A `livingdoc` is a document in our system. It separates content from structure
 by using `Components`. A `Livingdoc` references a specific `Design` which
 defines the available `Components` that can be used in the document.
 
-## NewsNT
+## Design
+A list of `Components` and configurations how they can be used
+in a `Livingdoc` and how users can interact with these `Components` in the
+`Livingdocs Editor`.
 
-A print publishing system.
+## Component library
+The component library is one of our core concepts. A component could be a `paragraph` or `author-card`, etc. You can define as many components as you wish within a design. Those will be available in the 'livingdocs-editor' then.
 
-## Project
+## Livingdocs-server
+The server is a node.js application. It is the backend of a Livingdocs instance.
 
-Represents an organisation and consists of users and channels.
+## Livingdocs-editor
+The editor is an Angular web application. It is the user interface implementation of a Livingdocs instance.
 
-## Upstream
+## Livingdocs-...-boilerplate
+Our boilerplates are recipes to quickly get one started with a custom downstream implementation of our core products such as the editor or server.
 
+## Upstream && Downstream
 *Upstream* is a package/repository which is integrated in another project called
 *downstream*. In our case the *upstreams* are our core `livingdocs-editor` and
 `livingdocs-server`. They are provided as npm packages (semantic versioning) and
 can be used by a *downstream* project, e.g., `livingdocs-server-downstream`. The
 `livingdocs-framework` package cannot be installed separately, it is a core
 package that cannot be used as an *upstream*.
+
+## Channel
+Represents a collection of documents. All documents in a `channel` must use
+the same `design`. A `channel` also defines the `Renditions`.
+
+## Project
+Represents an organisation and consists of users and channels.
+
+## Delivery
+The frontend for the end-user. The delivery will consume data from the livingdocs-server and display the data. An example delivery would be our [magazine-example](https://jovial-shaw-3479ee.netlify.com/).
+
+## [HuGO](http://www.sternwald.com/hugo/)
+A Digital Assets Management product developed and maintained by Sternwald, used
+to manage images and agency reports in large numbers. Also acts as a proxy for
+our Print Api to print publishing systems like `NewsNT` or `WoodWing`.
+
+## NewsNT
+A print publishing system.


### PR DESCRIPTION
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/2535

## description:
We want to improve the glossary as part of the new evaluation guide. 

## Improvements
- New structure (Livingdoc -> design -> component library) our core concepts are at the top
- Enhanced the glossary 
    - _Livingdocs server/editor description_
    - _delivery and boilerplate explanation_
    - _added description for what a component library is_