### PR TITLE
Add data-migration examples to the enterprise documentation 

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -60,8 +60,10 @@
 ## Design Howtos
 
 * [Create a Bullet List Component](reference-docs/common-designs/list_example.md)
-* [Running and Defining Design Migrations](concepts/document-migrations/migrations.md)
-
+* [Running and defining design migrations](concepts/document-migrations/migrations.md)
+  * [Example: Removing a directive](concepts/document-migrations/examples/remove_directive.md)
+  * [Example: Renaming a directive](concepts/document-migrations/examples/rename_directive.md)
+  * [Example: Adding a metadata field](concepts/document-migrations/examples/add_metadata_field.md)
 
 ## General Howtos
 

--- a/concepts/document-migrations/examples/add_metadata_field.md
+++ b/concepts/document-migrations/examples/add_metadata_field.md
@@ -1,0 +1,46 @@
+## Adding a metadata field
+
+Adding a new metadata field is not a breaking change but it is a common use case that you want to update your old documents with the new metadata entry. Additions of metadata have nothing to do with the design. The design can only define an automated field extractor for metadata, but not the metadata itself. The definition of the metadata is done in the server.
+
+In this example we will introduce a new metadata field "title" and prefill it in all documents with the value of the title field of the first header found in the document (if any).
+
+_You will first need to configure a design for the migrations to work._
+
+## Further reference
+You can find various files such as demo designs, tests and code snippets used [here in our boilerplate](https://github.com/livingdocsIO/livingdocs-server-boilerplate/pull/132/files) before they were removed in favor of putting them into the documentation.
+
+## Sample code snippet: 
+```js
+const _ = require('lodash')
+const liSDK = require('@livingdocs/node-sdk')
+const testDesignV1 = require('../../test/support/designs/test_design_1.0.0')
+
+// The grunt task 'data-migrations' will call this migration method with every
+// document of the project you specify in the task.
+exports.migrate = function ({serializedLivingdoc, metadata} = {}, callback) {
+  // You can work directly on the JSON or create a livingdoc instance from
+  // it and use the livingdoc API. We do the latter in this example.
+  const livingdoc = liSDK.document.create({
+    content: serializedLivingdoc.content,
+    design: testDesignV1
+  })
+
+  // We get the first header component in the document
+  const headers = livingdoc.componentTree.find('header')
+  const firstHeader = _.first(headers)
+  if (firstHeader) {
+    // And from this first header component we get the title directive and assign
+    // its value to the metadata field "title"
+    const titleDirective = firstHeader.directives.get('title')
+    metadata.title = titleDirective.getContent()
+  }
+
+  // return the modified serializedLivingdoc and metadata
+  // those will overwrite the ones you got as an input and the migration is
+  // done.
+  callback(null, {
+    serializedLivingdoc: livingdoc.serialize(),
+    metadata
+  })
+}
+```

--- a/concepts/document-migrations/examples/remove_directive.md
+++ b/concepts/document-migrations/examples/remove_directive.md
@@ -1,0 +1,80 @@
+## Removing a directive
+
+Removing a directive in a design is a breaking change.
+To denote it in the design you should use a major semver version (http://semver.org/). In any case you need to write a data migration in order to be able to open old documents with the new design. The below code is a sample migration for a design change that removes an editable directive called "author" from a component. 
+
+_You will first need to configure a design for the migrations to work._
+
+## Further reference
+You can find various files such as demo designs, tests and code snippets used [here in our boilerplate](https://github.com/livingdocsIO/livingdocs-server-boilerplate/pull/132/files) before they were removed in favor of putting them into the documentation.
+
+## Sample code snippet: 
+```js
+// Sample component "header", version 1.0.0 with editable directive "author"
+// <div>
+//   <h2 doc-editable="title">Title</h2>
+//   <img doc-image="image"/>
+//   <div>
+//     <span doc-editable="date">Date</span>
+//     <span doc-editable="author">Author</span>
+//   </div>
+// </div>
+
+// Sample component "header", version 2.0.0 without ediatble directive "author"
+// <div>
+//   <h2 doc-editable="title">Title</h2>
+//   <img doc-image="image"/>
+//   <div>
+//     <span doc-editable="date">Date</span>
+//   </div>
+// </div>
+
+// These designs are loaded for test and tutorial purposes. In your migrations
+// you will want to load your own design.
+const _ = require('lodash')
+const liSDK = require('@livingdocs/node-sdk')
+const testDesignV1 = require('../../test/support/designs/test_design_1.0.0')
+
+// Method name must be "migrate"
+// Parameters:
+//   serializedLivingdoc: The Livingdocs data model (JSON)
+//   metadata: The document's metadata (JSON)
+// Return:
+//  serializedLivingdoc: will overwrite the input
+//  metadata: will overwrite the input
+//
+// The grunt task 'data-migrations' will call this migration method with every
+// document of the project you specify in the task.
+exports.migrate = function ({serializedLivingdoc, metadata} = {}, callback) {
+  // You can work directly on the JSON or create a livingdoc instance from
+  // it and use the livingdoc API. We do the latter in this example.
+
+  const livingdoc = liSDK.document.create({
+    content: serializedLivingdoc.content,
+    design: testDesignV1
+  })
+
+  // First we get all the header components in this document. This is the
+  // component for which we need to remove the 'author' directive
+  const headers = livingdoc.componentTree.find('header')
+  _.each(headers, function (header) {
+    // Then we get the author directive from the header component.
+    // Each component has a collection of directives where you can get a single
+    // directive by directives.get(directiveName)
+    // And yes, the directiveName has to be unique within a component
+    const authorDirective = header.directives.get('author')
+    // In order to prepare this document for a design version that has no author
+    // directive in the header component, we need to simply set the content to
+    // undefined.
+    authorDirective.setContent(undefined)
+  })
+
+  // return the modified serializedLivingdoc and metadata
+  // those will overwrite the ones you got as an input and the migration is
+  // done.
+  callback(null, {
+    serializedLivingdoc: livingdoc.serialize(),
+    metadata
+  })
+}
+```

--- a/concepts/document-migrations/examples/rename_directive.md
+++ b/concepts/document-migrations/examples/rename_directive.md
@@ -1,0 +1,106 @@
+## Renaming a directive
+
+Renaming or moving a directive in a design is a breaking change. To denote it in the design you should use a major semver version (http://semver.org/). In any case you need to write a data migration in order to be able to open old documents with the new design. The below code is a sample migration for a design change that renames an image directive called "image" to "teaser".
+
+_You will first need to configure a design for the migrations to work._
+
+## Further reference
+You can find various files such as demo designs, tests and code snippets used [here in our boilerplate](https://github.com/livingdocsIO/livingdocs-server-boilerplate/pull/132/files) before they were removed in favor of putting them into the documentation.
+
+## Sample code snippet: 
+```js
+// Sample component "header", version 2.0.0 with image directive "image"
+// <div>
+//   <h2 doc-editable="title">Title</h2>
+//   <img doc-image="image"/>
+//   <div>
+//     <span doc-editable="date">Date</span>
+//   </div>
+// </div>
+
+// Sample component "header", version 3.0.0 with image directive "teaser"
+// <div>
+//   <h2 doc-editable="title">Title</h2>
+//   <img doc-image="teaser"/>
+//   <div>
+//     <span doc-editable="date">Date</span>
+//   </div>
+// </div>
+
+// These designs are loaded for test and tutorial purposes. In your migrations
+// you will want to load your own design.
+const _ = require('lodash')
+const liSDK = require('@livingdocs/node-sdk')
+const testDesignV2 = require('../../test/support/designs/test_design_2.0.0')
+const testDesignV3 = require('../../test/support/designs/test_design_3.0.0')
+
+// Method name must be "migrate"
+// Parameters:
+//   serializedLivingdoc: The Livingdocs data model (JSON)
+//   metadata: The document's metadata (JSON)
+// Return:
+//  serializedLivingdoc: will overwrite the input
+//  metadata: will overwrite the input
+//
+// The grunt task 'data-migrations' will call this migration method with every
+// document of the project you specify in the task.
+exports.migrate = function ({serializedLivingdoc, metadata} = {}, callback) {
+  // You can work directly on the JSON or create a livingdoc instance from
+  // it and use the livingdoc API. We do the latter in this example.
+  const livingdocV2 = liSDK.document.create({
+    content: serializedLivingdoc.content,
+    design: testDesignV2
+  })
+
+  // First we save all the data from the old image directive.
+  // This is an array since in theory there could be more than one header in
+  // the document.
+  const imagesData = []
+  const headersV2 = livingdocV2.componentTree.find('header')
+  _.each(headersV2, function (header) {
+    const imageDirective = header.directives.get('image')
+    const imageData = imageDirective.getContent()
+    imagesData.push(imageData)
+    // We set the image directive's content to undefined in order to reset it
+    // NOTE: the image directive has no reset API yet, thus we use the private
+    // API.
+    imageDirective.content = undefined
+  })
+
+  // In order to add the teaser we need to load the document in the new design
+  // only the new design has a "teaser" directive.
+  const livingdocV3 = liSDK.document.create({
+    content: livingdocV2.serialize().content,
+    design: testDesignV3
+  })
+
+  const headersV3 = livingdocV3.componentTree.find('header')
+  _.each(headersV3, function (header, index) {
+    // For each header in the document loaded with the new design we get the
+    // "teaser" directive
+    const teaserDirective = header.directives.get('teaser')
+    const respectiveImageData = imagesData[index]
+    // and set the image data we got above to it.
+    // NOTE: we need to set the url to the originalUrl of the data we got. This
+    // is because the Livingdocs Framework automatically applies image service
+    // information to an image URL.
+    teaserDirective.setContent({
+      url: respectiveImageData.originalUrl,
+      width: respectiveImageData.width,
+      height: respectiveImageData.height,
+      mimeType: respectiveImageData.mimeType,
+      imageService: respectiveImageData.imageService,
+      origins: respectiveImageData.origins,
+      crop: respectiveImageData.crop
+    })
+  })
+
+  // return the modified serializedLivingdoc and metadata
+  // those will overwrite the ones you got as an input and the migration is
+  // done.
+  callback(null, {
+    serializedLivingdoc: livingdocV3.serialize(),
+    metadata
+  })
+}
+```

--- a/concepts/document-migrations/migrations.md
+++ b/concepts/document-migrations/migrations.md
@@ -120,10 +120,10 @@ The following diagram visualizes the most important states and actions:
 
 ## Examples
 
-The boilerplate app implements three example migrations that you can take as a starting point for your own migrations. (Don't run the example migrations, they are using a sample design which is not configured).
+We've described three example migrations that you can take as a starting point for your own migrations. 
 
-1. [Migration script after removing a directive from a component](https://github.com/livingdocsIO/livingdocs-server-boilerplate/blob/master/app/data-migrations/000_example_remove_directive.js)
+1. [Migration script after removing a directive from a component](./examples/remove_directive.md)
 
-2. [Migration script after renaming a directive on a component](https://github.com/livingdocsIO/livingdocs-server-boilerplate/blob/master/app/data-migrations/000_example_rename_directive.js)
+2. [Migration script after renaming a directive on a component](./examples/rename_directive.md)
 
-3. [Migration script to initialize a new metadata field](https://github.com/livingdocsIO/livingdocs-server-boilerplate/blob/master/app/data-migrations/000_example_add_metadata_field.js)
+3. [Migration script to initialize a new metadata field](./examples/add_metadata_field.md)


### PR DESCRIPTION
## Overview:
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/2418

## Description:
We want to remove the data migration examples from the boilerplate and instead have the examples within our enterprise documentation

## Relation: 
This should be merged first: https://github.com/livingdocsIO/livingdocs-server-boilerplate/pull/132