### PR TITLE
Fix link to windows10 setup guide

### DIFF
--- a/walkthroughs/getting-started-with-local-development.md
+++ b/walkthroughs/getting-started-with-local-development.md
@@ -4,7 +4,7 @@ Both the server and the editor ship with a default configuration, that works out
 
 ## Operating system
 
-Livingdocs runs under Mac OSX, Linux and Windows 10. For Windows 10 proceed first to [setup Windows 10](./setup_windows10)
+Livingdocs runs under Mac OSX, Linux and Windows 10. For Windows 10 proceed first to [setup Windows 10](./setup_windows10.md)
 
 ## Install Docker
 


### PR DESCRIPTION
Not listed in, but still addressing livingdocsIO/livingdocs-planning#2549