### PR TITLE
Move info for documentation maintainers out of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,3 @@ Please let us know about gaps or errors in our documentation at [documentation@l
 
 
 (If you are viewing this documentation on our Github repository, there is a new nicer view of it at https://docs.livingdocs.io)
-
-
-## Usage
-
-This documentation is built using [GitBook](https://www.gitbook.com/). If you want to run it locally, follow the [Installation and Setup section](https://toolchain.gitbook.com/setup.html). The gist is:
-
-*Initial installation*
-
-```
-# Install `gitbook` commandline tool
-npm install gitbook-cli -g
-# Install plugins
-gitbook install
-```
-
-
-*Run*
-
-```
-gitbook serve
-```

--- a/dev_readme.md
+++ b/dev_readme.md
@@ -1,0 +1,33 @@
+# Gitbook Usage
+
+This documentation is built using [GitBook](https://www.gitbook.com/). If you want to run it locally, follow the [Installation and Setup section](https://toolchain.gitbook.com/setup.html). The gist is:
+
+*Initial installation*
+
+```
+# Install `gitbook` commandline tool
+npm install gitbook-cli -g
+# Install plugins
+gitbook install
+```
+
+
+*Run*
+
+```
+gitbook serve
+```
+
+
+## Debug Links in the documentation
+
+```bash
+npm install -g markdown-link-check
+markdown-link-check SUMMARY.md -q
+```
+
+
+Check links in all files in the project:
+```bash
+find -E . -regex ".*\.(md)" | xargs -n 1 markdown-link-check -q
+```


### PR DESCRIPTION
## Description

Info how to build and deploy the documentation should not be part of the documentation for customers.