### PR TITLE
Reorganisation of the navigation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,9 +2,16 @@
 
 * [Getting started](./getting_started.md)
 
-* [Setting up Livingdocs locally](walkthroughs/getting-started-with-local-development.md)
+
+## Concepts
 
 * [Glossary](./DICTIONARY.md)
+* [Livingdocs Design and Components](reference-docs/common-designs/create_designs.md)
+* [Metadata Plugins](walkthroughs/metadata/metadata-examples.md)
+* [Image Services](concepts/images/image-services.md)
+* [Includes](reference-docs/doc-includes/intro.md)
+* [Document Copy](concepts/copying-documents/document_copy_feature.md)
+
 
 ## Videos
 
@@ -12,63 +19,65 @@
 * [Livingdocs Boilerplate Intro](videos/boilerplate_intro.md)
 * [Livingdocs Includes](videos/includes.md)
 
-## Reference
 
-* [Channel config](reference-docs/server-configuration/channel-config.md)
-* [Content-type config](reference-docs/server-configuration/content-type-config.md)
-* Data model
-  * [Livingdoc](reference-docs/common-livingdoc/livingdoc.md)
-  * [Component tree](reference-docs/common-livingdoc/component_tree.md)
-  * [Component model](reference-docs/common-livingdoc/component_model.md)
-  * [Directives](reference-docs/common-livingdoc/directives.md)
-* Design
-  * [Component config](reference-docs/common-designs/component_config.md)
-  * [Design config](reference-docs/common-designs/design_config.md)
-* Editor config
+## Reference Documentation
+
+* Server
+  * [Configuration File](reference-docs/server-configuration/config.md)
+  * [Channel Config](reference-docs/server-configuration/channel-config.md)
+  * [Content-Type Config](reference-docs/server-configuration/content-type-config.md)
+  * [Metadata on the Server](reference-docs/server-configuration/metadata.md)
+  * [Hooks](reference-docs/server-configuration/hooks.md)
+  * [Import API](reference-docs/server-import-api/import_api.md)
+  * [Specify Loaded Features](reference-docs/server-configuration/stack.md)
+  * [Events](reference-docs/server-extensions/events.md)
+  * [Logs](reference-docs/server-configuration/logging.md)
+  * [Single Sign-On](reference-docs/server-configuration/single_sign-on.md)
+  * [Create Users](walkthroughs/create-users.md)
+  * [Server Admin Commands](reference-docs/server-configuration/admin-commands.md)
+* Editor
   * [Document Editing Features](reference-docs/editor-configuration/editing-features.md)
+  * [Text Editing Config](reference-docs/editor-configuration/text-editing.md)
   * [Menu and Dashboards](reference-docs/editor-configuration/menu-and-dashboards.md)
   * [Document Drag & Drop](reference-docs/editor-configuration/document-drag-drop.md)
+  * [Image Cropper Config](reference-docs/editor-configuration/image-cropping.md)
+  * [Image Source Policy Config](reference-docs/editor-configuration/image-source-policy.md)
+  * [Metadata Configuration](reference-docs/editor-configuration/metadata.md)
   * [Login](reference-docs/editor-configuration/login.md)
-* [Events](reference-docs/server-extensions/events.md)
-* [Image cropper config](reference-docs/editor-configuration/image-cropping.md)
-* [Image source policy config](reference-docs/editor-configuration/image-source-policy.md)
-* [Image services](concepts/images/image-services.md)
-* [Import API](reference-docs/server-import-api/import_api.md)
+* Livingdocs Design
+  * [Design Config](reference-docs/common-designs/design_config.md)
+  * [Component Config](reference-docs/common-designs/component_config.md)
+* Livingdocs Content Model
+  * [Livingdoc](reference-docs/common-livingdoc/livingdoc.md)
+  * [Component Tree](reference-docs/common-livingdoc/component_tree.md)
+  * [Component Model](reference-docs/common-livingdoc/component_model.md)
+  * [Directives](reference-docs/common-livingdoc/directives.md)
 * Includes
-  * [Include server config](reference-docs/doc-includes/server_customization.md)
-  * [Include user interfaces](reference-docs/doc-includes/editor_customization.md)
-  * [Includes with multiple services](reference-docs/doc-includes/service_multiselect.md)
-* [Metadata on the server](reference-docs/server-configuration/metadata.md)
-* [Metadata editor configuration](reference-docs/editor-configuration/metadata.md)
+  * [Include Server Config](reference-docs/doc-includes/server_customization.md)
+  * [Include User Interfaces](reference-docs/doc-includes/editor_customization.md)
+  * [Includes with Multiple Services](reference-docs/doc-includes/service_multiselect.md)
 * [Print API](reference-docs/server-print-api/print-api.md)
-* Server
-  * [configuration file](reference-docs/server-configuration/config.md)
-  * [hooks](reference-docs/server-configuration/hooks.md)
-  * [single sign-on](reference-docs/server-configuration/single_sign-on.md)
-* [Stack](reference-docs/server-configuration/stack.md)
-* [Text editing config](reference-docs/editor-configuration/text-editing.md)
-* [Document copy](concepts/copying-documents/document_copy_feature.md)
 
-## Design Guides
 
-* [Introduction to design and components](reference-docs/common-designs/create_designs.md)
-* [How to do a bullet list](reference-docs/common-designs/list_example.md)
-* [Running and defining design migrations](concepts/document-migrations/migrations.md)
+## Design Howtos
 
-## Customizing Guides
+* [Create a Bullet List Component](reference-docs/common-designs/list_example.md)
+* [Running and Defining Design Migrations](concepts/document-migrations/migrations.md)
 
-* [Register a custom feature](walkthroughs/add_customizations.md)
-* [Metadata examples](walkthroughs/metadata/metadata-examples.md)
-* [Implement includes](reference-docs/doc-includes/intro.md)
-* [Configure article embed and list](reference-docs/doc-includes/embed_and_list.md)
-* [Use the Publish Hooks](reference-docs/server-extensions/publish-hooks.md)
-* [Validate task completion](walkthroughs/validate_tasks.md)
-* [Implement single-sign-on (SSO)](walkthroughs/github-login.md)
-* [Add an Instagram embed](walkthroughs/instagram_embed.md)
-* [Use push notifications and custom dashboard item](walkthroughs/push_notifications.md)
-* [Enable multi-language support](walkthroughs/setup_multilanguage.md)
-* [A possible translation system](walkthroughs/translations_example.md)
-* [A possible routing system](reference-docs/server-public-api/routing-system.md)
+
+## General Howtos
+
+* [Register a Custom Server Feature](walkthroughs/add_customizations.md)
+* [Configure Includes: Article Embed and List](reference-docs/doc-includes/embed_and_list.md)
+* [Assign Access Rights](administration/access_rights.md)
+* [Use the Publish Hooks](reference-docs/server-extensions/hooks.md)
+* [Validate Task Completion](walkthroughs/validate_tasks.md)
+* [Implement Single Sign-On](walkthroughs/github-login.md)
+* [Add an Instagram Embed](walkthroughs/instagram_embed.md)
+* [Use Push Notifications and Custom Dashboard Item](walkthroughs/push_notifications.md)
+* [Enable Multi-Language Support](walkthroughs/setup_multilanguage.md)
+* [A Possible Translation System](walkthroughs/translations_example.md)
+* [A Possible Routing System](reference-docs/server-public-api/routing-system.md)
 * [Hugo Drag and Drop](reference-docs/server-extensions/hugo-dnd.md)
 
 
@@ -78,10 +87,10 @@
 
   * [Hardware Requirements](setup-and-deployment/hardware-requirements.md)
   * [Architecture](setup-and-deployment/high-availability/README.md)
-    * [high-availability](setup-and-deployment/high-availability/high-availability-setup.md)
+    * [High-Availability](setup-and-deployment/high-availability/high-availability-setup.md)
   * [Docker](setup-and-deployment/docker/README.md)
-    * [Build docker images](setup-and-deployment/docker/build-docker-images.md)
-  * [External services](setup-and-deployment/external-services.md)
+    * [Build Docker Images](setup-and-deployment/docker/build-docker-images.md)
+  * [External Services](setup-and-deployment/external-services.md)
   * [Proxy](setup-and-deployment/proxy.md)
   * [NPM Tokens](setup-and-deployment/npm/access-private-npm-modules.md)
 
@@ -90,12 +99,10 @@
 * [How to do a Stress Test](https://github.com/DaRaFF/stress-test-example#how-to-make-a-simple-stress-test)
 * [How to Configure and Interpret Varnish](reference-docs/maintenance/how-to-varnish.md)
 
-## Administration
 
-* [Create Users](walkthroughs/create-users.md)
-* [Assign access rights](administration/access_rights.md)
-* [Logs](reference-docs/server-configuration/logging.md)
-* [Server Admin Commands](reference-docs/server-configuration/admin-commands.md)
+## Core Development
+
+* [Setup for Core Development](walkthroughs/getting-started-with-local-development.md)
 
 <!-- ## Livingdocs core development
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,14 +3,14 @@
 * [Getting started](./getting_started.md)
 
 
-## Concepts
+## Evaluation Guide
 
-* [Glossary](./DICTIONARY.md)
+* [System Prerequisites](walkthroughs/getting-started-with-local-development.md)
 * [Livingdocs Design and Components](reference-docs/common-designs/create_designs.md)
 * [Metadata Plugins](walkthroughs/metadata/metadata-examples.md)
 * [Image Services](concepts/images/image-services.md)
 * [Includes](reference-docs/doc-includes/intro.md)
-* [Document Copy](concepts/copying-documents/document_copy_feature.md)
+* [Glossary](./DICTIONARY.md)
 
 
 ## Videos
@@ -67,6 +67,7 @@
 
 ## General Howtos
 
+* [Use Document Copy](concepts/copying-documents/document_copy_feature.md)
 * [Register a Custom Server Feature](walkthroughs/add_customizations.md)
 * [Configure Includes: Article Embed and List](reference-docs/doc-includes/embed_and_list.md)
 * [Assign Access Rights](administration/access_rights.md)
@@ -100,9 +101,6 @@
 * [How to Configure and Interpret Varnish](reference-docs/maintenance/how-to-varnish.md)
 
 
-## Core Development
-
-* [Setup for Core Development](walkthroughs/getting-started-with-local-development.md)
 
 <!-- ## Livingdocs core development
 

--- a/reference-docs/common-designs/create_designs.md
+++ b/reference-docs/common-designs/create_designs.md
@@ -1,4 +1,5 @@
-# Create designs
+
+# Livingdocs Design and Components
 
 This guide references the [Livingdocs timeline design](https://github.com/livingdocsIO/livingdocs-design-timeline),
  which you can use as a starting point for your own designs. We advise you to clone this repository now to follow the subsequent examples.

--- a/reference-docs/server-configuration/admin-commands.md
+++ b/reference-docs/server-configuration/admin-commands.md
@@ -1,6 +1,6 @@
 # Admin Commands
 
-There a lot of commands which can be executed on the server.
+There are a lot of commands which can be executed on the server.
 
 ## Description of the Commands
 * [Help](#help)

--- a/walkthroughs/metadata/metadata-examples.md
+++ b/walkthroughs/metadata/metadata-examples.md
@@ -1,10 +1,13 @@
-# Example 1: Full Example on how to Introduce a Metadata Field with a Standard Metadata Plugin
+
+# Metadata Plugins
+
+## Example 1: Full Example on how to Introduce a Metadata Field with a Standard Metadata Plugin
 
 Say we want to create a new metadata field "catchline" for articles of your default web channel. The catchline should be a simple text input on the publish panel that journalists can edit.
 
 For details have a look at the [server configuration reference documentation](../../reference-docs/server-configuration/metadata.md)
 
-## Server
+#### Server
 
 (Note: we assume the use of the [Livingdocs server boilerplate](https://github.com/livingdocsIO/livingdocs-server-boilerplate) here)
 
@@ -48,7 +51,7 @@ metadataFormArrangement: [
 6. After you have setup your new metadata field you can use it in the editor.
 
 
-# Example 2: Create your own Metadata Plugin
+## Example 2: Create your own Metadata Plugin
 
 If you want to use a custom metadata plugin, you have to do the following steps on the server:
 
@@ -87,7 +90,7 @@ metadata: {
 ```
 
 
-# Example 3: Fully customized metadata component
+## Example 3: Fully customized metadata component
 
 Lets add a new metadata field, a `slug`, in the publish screen.
 
@@ -101,7 +104,7 @@ https://www.example.com/a-way-to-compare-schools
 ![Slug form metadata](./slug-metadata-form.png)
 
 
-## Server
+#### Server
 
 First we need to define a new property in our Elasticsearch mapping.
 
@@ -178,7 +181,7 @@ module.exports = {
 ```
 
 
-## Editor
+#### Editor
 
 In the editor we need to create the form defined in the server as `'bp-slug-form'`.
 


### PR DESCRIPTION
## Description

Reorganisation of the main Navigation. The main focus was on the reference documentation and to indicate the context of the different docs better. Also I tried to separate Concepts/Guides from Howtos. And a few small things like Title Casing all the links and renaming some entries.

This PR is best to review locally by running `gitbook serve` and checking out what you like, don't like in the navigation.