### PR TITLE
fix: Styling for doc-include example

### DIFF
--- a/reference-docs/doc-includes/intro.md
+++ b/reference-docs/doc-includes/intro.md
@@ -22,7 +22,7 @@ The last point is worth mentioning again: rendering of a `doc-include` is done o
 
 You should be familiar with [Livingdocs directives](../common-designs/component_config.md#directives) for this section.
 
-```component.html
+```html
 <script type="ld-conf">
 {
   "name": "example",


### PR DESCRIPTION
- Before: ![](http://screenshots.200ok.ch/screenshot_2019_02_21-6cd4344e.png)
- After: ![](http://screenshots.200ok.ch/screenshot_2019_02_21-4218692a.png)
