### PR TITLE
Document `selectedImageService

### DIFF
--- a/concepts/images/image-services.md
+++ b/concepts/images/image-services.md
@@ -45,7 +45,7 @@ In order to see an image in a HTML document, Livingdocs needs to generate the HT
 
 Below is an example workflow that summarizes the whole process.
 
-A user uploads an image to the Livingdocs editor, the corresponding file is stored on Amazon S3 and the URL to the Amazon file is available on the component as `originalUrl`. The framework chooses the correct image service (e.g. ImgIX) for generating the correct HTML markup in the document that is shown in the Livingdocs editor. (The image service to be used is configured in the Livingdocs editor. Let's say `ImgIX` is configured.) The framework loads the `imgix_image_service` and calls the `set` method which will generate an `img` tag with a URL that fits the ImgIX url specification (https://docs.imgix.com/setup/serving-images). The browser then renders the image by querying ImgIX for the respective image.
+A user uploads an image to the Livingdocs editor, the corresponding file is stored on Amazon S3 and the URL to the Amazon file is available on the component as `originalUrl`. The framework chooses the correct image service (e.g. ImgIX) for generating the correct HTML markup in the document that is shown in the Livingdocs editor. (The image service to be used is configured via `selectedImageService`. Let's say `ImgIX` is configured.) The framework loads the `imgix_image_service` and calls the `set` method which will generate an `img` tag with a URL that fits the ImgIX url specification (https://docs.imgix.com/setup/serving-images). The browser then renders the image by querying ImgIX for the respective image.
 
 ## Why image services?
 
@@ -66,7 +66,7 @@ Srcset only works for inline images (`img` tag). If you use a background image, 
 
 ## Configuring an image service
 
-You currently need to configure your image service in both the editor and the server. We will push towards a server-only configuration. In the editor you configure which image service to use and the configuration for this image service. In the server you just add the configuration for the image service.
+You need to configure your image service in the server. You add the configuration for one or more image services as well as the selected image service.
 
 Below we'll outline the configuration for both ImgIX and resrc.it.
 
@@ -74,20 +74,11 @@ Below we'll outline the configuration for both ImgIX and resrc.it.
 
 The ImgIX configuration uses `srcset`. If you don't know about this HTML standard yet, refer to this article first: https://ericportis.com/posts/2014/srcset-sizes/
 
-#### Editor
-
-```js
-  app: {
-    imageService: 'imgix'
-  }
-```
-
-The `imageService` field tells Livingdocs which image service should be used.
-
 #### Server
 
 ```js
 documents: {
+  selectedImageService: 'imgix',
   imageServices: {
     imgix: {
       host: 'https://livingdocs-dev.imgix.net',
@@ -109,10 +100,10 @@ documents: {
   }
 }
 ```
-
+The `selectedImageService` field tells Livingdocs which image service should be used.
 The `imageServices` contains the configurations for one or more image services.
 
-You can in theory configure several images services in the server, but as of now only one can be used (the one specified in the editor config).
+You can in theory configure several images services in the server, but as of now only one can be used (the one specified in selectedImageService).
 
 The `host` is simply where your ImgIX images are served from.
 If `preferWebp` is set to `true` Livingdocs will pass the `auto=format` parameter (https://docs.imgix.com/apis/url/auto).
@@ -128,20 +119,11 @@ For background images you can simply set a fixed max-width, so that each backgro
 
 ### Resrc.it
 
-#### Editor
-
-```js
-app: {
-  imageService: 'resrc.it',
-}
-```
-
-The `imageService` field tells Livingdocs which image service should be used.
-
 #### Server
 
 ```js
 documents: {
+  selectedImageService: 'resrc.it'
   imageServices: {
     'resrc.it': {
       host: 'https://app.resrc.it',
@@ -151,10 +133,10 @@ documents: {
   }
 }
 ```
-
+The `selectedImageService` field tells Livingdocs which image service should be used.
 The `imageServices` contains the configurations for one or more image services.
 
-You can in theory also configure several images services in the server, but as of now only one can be used (the one specified in the editor config).Î
+You can in theory also configure several images services in the server, but as of now only one can be used (the one specified in selectedImageService).
 
 The `host` is simply where your resrc.it images are served from. With `resrc.it` this is normally always the same.
 The `quality` setting allows you to choose a global quality for your images. In the range between 75 to 100 you normally don't see a difference.

--- a/reference-docs/server-configuration/config.md
+++ b/reference-docs/server-configuration/config.md
@@ -346,6 +346,7 @@ files: {
 
 ```js
 documents: {
+  selectedImageService: 'imgix',
   imageServices: {
     imgix: {} // imageService specific configuration
   }
@@ -492,6 +493,41 @@ images: {
 ```
 [config options](./config-storage-options.md) for `storage`.
 
+##### Image Service
+
+Livingdocs uses so-called image services to generate image URLs on the client and on the server. For the asset management you have to decide if you want to use a proxy or not.
+Without a proxy, just select your preferred image service, nothing else needs to be done.
+If you want to use a proxy (i.e. proxy image requests through Livingdocs), you need to use `liImageProxy`:
+```
+documents: {
+  selectedImageService: 'liImageProxy',
+  imageServices: {
+    liImageProxy: {
+      proxiedImageService: 'imgix',
+      host: 'http://localhost:9090',
+      proxyEndpoint: 'api/v1/images',
+      preferWebp: true,
+      backgroundImage: {
+        maxWidth: 2048
+      },
+      srcSet: {
+        defaultWidth: 1024,
+        widths: [
+          2048,
+          1024,
+          620,
+          320
+        ],
+        sizes: ['100vw']
+      }
+    }
+  }
+}
+```
+
+The image service `liImageProxy` is only used as a proxy. Internally and for the delivery of your images to end customers you will use an internally proxied image service (`proxiedImageService`).
+(Note: Currently, this is only tested with ImgIX, other image services are not officially supported)
+
 
 ##### Setting up the Elastic Search Mapping
 
@@ -513,44 +549,21 @@ Then the Image index can be created. This is included in the `grunt setup` task,
 ./bin/index.js create-image-index
 ```
 
-##### Feature Flag
+##### Feature Flag and internal image service
 The endpoint /upload can function with Asset Management functionality or without. The change can be configured in the environment with:
 
 ```
   assetManagement: {
-    enabled: true
-  },
+    enabled: true,
+    paginationSize: 25
+  }
 ```
+
 The feature flag is ignored by the other Asset Management endpoints (`GET /images?fullText` search and `GET /images/:id` Image information endpoint), because they are new endpoints and would only be called explicitly by an Editor which is configured for using the Asset Management.
 
+The `paginationSize` tells the asset management how many images to show on one page.
+
 Make sure that you disable the Asset Management in the Editor as well and make sure that you configure the image services properly too.
-
-##### Image Service
-This functionality introduces a new image-service `liImageProxy`. It's a proxy around ImgIX. Therefore it includes some new (proxy specific) configuration and all configuration that's required for ImgIX:
-
-```js
-    imageServices: {
-      liImageProxy: {
-        host: 'http://localhost:9090',
-        proxyEndpoint: 'api/v1/images',
-        paginationSize: 25,
-        preferWebp: true,
-        backgroundImage: {
-          maxWidth: 2048
-        },
-        srcSet: {
-          defaultWidth: 1024,
-          widths: [
-            2048,
-            1024,
-            620,
-            320
-          ],
-          sizes: ['100vw']
-        }
-      }
-    }
-```
 
 
 ## Integrations


### PR DESCRIPTION
We changed the image service selection from editor-side to server-side: https://github.com/livingdocsIO/livingdocs-planning/issues/2536

This PR documents the changes.

Other changes documented:
- make clear that DAM needs `liImageProxy`
- moved `paginationSize` from `liImageProxy` to `assetManagment`
- introduced `proxiedImageService` in `liImageProxy`