### PR TITLE
feat(links): extend documentation for links

### DIFF
--- a/reference-docs/editor-configuration/text-editing.md
+++ b/reference-docs/editor-configuration/text-editing.md
@@ -221,7 +221,7 @@ If you set the internal hosts as regex, you can define default behavior for inte
     allowRelativeUrls: false,
     allowAnchorLinks: false,
     allowMailToUrls: true,
-    internalHostsRegex: ['^(https?://)?(www.)?internalLink.ch', '^(https?://)?(www.)?internalLink.com'],
+    internalHostsRegex: ['^(https?://)?(www.)?foo.com', '^(https?://)?(www.)?bar.io'],
     internalDefaults: {
       openInNewWindow: false,
       follow: true

--- a/reference-docs/editor-configuration/text-editing.md
+++ b/reference-docs/editor-configuration/text-editing.md
@@ -214,12 +214,22 @@ textcount: {
 ![Links](./links.png)
 
 #### Options
+If you set the internal hosts as regex, you can define default behavior for internal and external links.
 ```js
 {
   links:{
     allowRelativeUrls: false,
     allowAnchorLinks: false,
-    allowMailToUrls: true
+    allowMailToUrls: true,
+    internalHostsRegex: ['^(https?://)?(www.)?internalLink.ch', '^(https?://)?(www.)?internalLink.com'],
+    internalDefaults: {
+      openInNewWindow: false,
+      follow: true
+    },
+    externalDefaults: {
+      openInNewWindow: true, -> // will resolve to `<a target="_blank"></a>`
+      follow: false -> // will resolve to `<a rel="nofollow"></a>`
+    }
   }
 }
 ```


### PR DESCRIPTION
### Relations:
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/2681
Editor-PR: https://github.com/livingdocsIO/livingdocs-editor/pull/2697

### Description:
Alongside with extending our current link behavior with default configs, the documentation needs to showcase the configs as well.