### PR TITLE
Additional documentation for tasks

### DIFF
--- a/walkthroughs/add-custom-proofreading-task.md
+++ b/walkthroughs/add-custom-proofreading-task.md
@@ -27,6 +27,8 @@ metadata: [
     updateLastProofreadRevision: true,
     // you can pick a deadline date in the editor when starting with a task
     requestDeadline: true,
+    // define a link from the task to a dashboard. 'kanban-proofreading' is the handle of the dashboard in the editor-config
+    linkToDashboard: 'kanban-proofreading',
     // define beforeLabel/afterLabel of the 3 states requested/accepted/completed
     requested: {
       beforeLabel: 'Request proofreading',


### PR DESCRIPTION
Related PRs: https://github.com/livingdocsIO/livingdocs-editor/pull/2787

# Changelog

- add `linkToDashboard ` config property for `li-task-v2` metadata plugin