### PR TITLE
Document copy add example about matching

### DIFF
--- a/concepts/copying-documents/document_copy_feature.md
+++ b/concepts/copying-documents/document_copy_feature.md
@@ -170,6 +170,12 @@ module.exports = {
     // Excluded components are ignored during copying:
     match: 'responsive-image',
     exclude: true
+  }, { 
+
+    // OPTIONAL: matches all components without instructions and copies or excludes them.
+    // CAREFUL: if you copy all components, they have to be defined in both designs!
+    match: '*',
+    copy: true // OR exclude: true
   }],
 
 


### PR DESCRIPTION
### Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/2999

### Description
Adds a small example about copying/excluding all components without instructions