### PR TITLE
Email-configs: add httpOption config

### DIFF
--- a/reference-docs/server-configuration/config.md
+++ b/reference-docs/server-configuration/config.md
@@ -152,6 +152,8 @@ emails: {
     awsEmailSender: {
       from: 'Livingdocs <noreply@livingdocs.io>',
       module: 'nodemailer-ses-transport',
+      // for more options see the aws client config object:
+      // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html
       config: {
         accessKeyId: 'yourAccessKeyId',
         secretAccessKey: 'yourSecretAccessKey',

--- a/reference-docs/server-configuration/config.md
+++ b/reference-docs/server-configuration/config.md
@@ -155,7 +155,8 @@ emails: {
       config: {
         accessKeyId: 'yourAccessKeyId',
         secretAccessKey: 'yourSecretAccessKey',
-        region: 'eu-west-1'
+        region: 'eu-west-1',
+        httpOptions: {proxy: process.env.HTTP_PROXY}
       }
     }
   },


### PR DESCRIPTION
### Description

Since heute.at had some issues getting the emails to work, let's add what ended up working for them to our documentation.