### PR TITLE
docs: Add `contentType` specific image `sourcePolicy`

### DIFF
--- a/reference-docs/editor-configuration/image-source-policy.md
+++ b/reference-docs/editor-configuration/image-source-policy.md
@@ -4,26 +4,37 @@
 
 Different sources for images can be enabled and disabled. E.g. it is now possible to disable image uploads by users and only allow e.g to use images from HuGo.
 
-Editor configuration file:
+Example config with multiple sources:
+```js
+{
+  sourcePolicy: [{
+    provider: 'upload',
+    enabled: true
+  }, {
+    provider: 'hugo',
+    enabled: true
+  }, {
+    provider: 'url', 
+    enabled: true,
+    hosts: ['https://cdn.pixabay.com']
+  }]
+}
+```
+
+This config can be placed into the `editor` config and/or the server's `contentType` channelConfig (see below). If both are defined the `contentType` will take precedence.
+
+Editor config:
 ```js
 {
   images: {
-    sourcePolicy: [{
-      provider: 'upload',
-      enabled: true
-    }, {
-      provider: 'hugo',
-      enabled: true
-    }, {
-      provider: 'url',
-      enabled: true,
-      hosts: ['https://cdn.pixabay.com']
-    }]
+    sourcePolicy: [
+      // ...
+    ]
   }
 }
 ```
 
-images.sourcePolicy is a new config option which is optional. By default upload and hugo are enabled and url is disabled.
+This config is optional. By default upload and hugo are enabled and url is disabled.
 
 Current default policy:
 
@@ -35,6 +46,7 @@ const defaultPolicies = {
 }
 ```
 
-There is also a config that can be set in the contentType channelConfig property editorConfig.images.whitelist which is still respected.
+Please refer to the server configuration's `contentType` section to set the `sourcePolicy` there. 
+There is also a config that can be set in the `contentType` channelConfig property editorConfig.images.whitelist which is still respected.
 
-See: [ContentType configuration](../server-configuration/content-type-config)
+See: [ContentType configuration](../server-configuration/content-type-config.md)

--- a/reference-docs/server-configuration/content-type-config.md
+++ b/reference-docs/server-configuration/content-type-config.md
@@ -83,10 +83,25 @@ We plan to allow to move all layout options which are currently defined in the d
     },
 
     images: {
-      // whitelist of hosts for image urls that are drag & dropped into the editor
+      // Deprecated for `sourcePolicy` below: whitelist of hosts for image urls that are drag & dropped into the editor
       whitelist: ['//pixabay.com']
+
+      sourcePolicy: [
+        {
+          provider: 'upload',
+          enabled: true
+        }, {
+          provider: 'hugo',
+          enabled: false
+        }, {
+          provider: 'url',
+          enabled: true,
+          hosts: ['//pixabay.com']
+        }
+      ]
     }
   },
+
   // With 'documentCreationDisabled: true', you can't create documents with this content-type
   documentCreationDisabled: true, // default false
 }
@@ -125,8 +140,11 @@ module.exports = {
 }
 ```
 
+## Image Source Policy
+You may set a `contentType` specific sourcePolicy here. For details see: [Image Source Policy](../editor-configuration/image-source-policy.md))
 
-### Enable Push Notifications for a ContentType
+
+## Enable Push Notifications for a ContentType
 
 To enable push notifications for a specific content type you must have a metadata field called `pushNotifications`. Name and plugin must match exactly.
 ```js


### PR DESCRIPTION
Server PRs:
- `release-2019-09` https://tracking.nzzmg.ch/browse/WCMS-4663
- `master`

Editor PRs:
- `release-2019-09` https://github.com/livingdocsIO/livingdocs-editor/pull/3090
- `master`

Note the new `editor.images.sourcePolicy` contentType setting is a superset of the current `editor.images.whitelist`, therefore `whitelist` will be deprecated.