### PR TITLE
fix(cli): add docs for config-sync workflow

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -95,8 +95,8 @@
 
 ## CLI
 
-* [Dotfile](livingdocs-cli/cli-dotfile.md)
-* [Config Sync](livingdocs-cli/sync-configs.md)
+* [.livingdocs-cli](livingdocs-cli/cli-dotfile.md)
+* [Sync Project Configs](livingdocs-cli/sync-configs.md)
 
 ## Devops
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -93,6 +93,10 @@
 * [Asset Management](reference-docs/common-livingdoc/asset-management.md)
 * [Author Management](walkthroughs/prefill-author.md)
 
+## CLI
+
+* [Dotfile](livingdocs-cli/cli-dotfile.md)
+* [Config Sync](livingdocs-cli/sync-configs.md)
 
 ## Devops
 

--- a/livingdocs-cli/cli-dotfile.md
+++ b/livingdocs-cli/cli-dotfile.md
@@ -1,0 +1,110 @@
+# .livingdocs-cli
+
+## Set up a cli dotfile
+
+In case you are working with multiple projects and/or environments it becomes
+cumbersome to set tokens, hosts and other params.
+
+To make this easier you can set up a dotfile that allows you to pass
+`env` and `project` to all commands where this makes sense instead of
+using e.g. the `LI_TOKEN` environment variable.
+
+
+#### Multiple environments
+
+`.livingdocs-cli` file in the root of your working directory:
+```json
+{
+  "environments": {
+    "local": {
+      "host": "https://localhost:9000",
+      "token": "local-token",
+      "distFolder": "./config-sync/local"
+    },
+    "development": {
+      "host": "https://server-development.example.dev",
+      "token": "dev-token",
+      "distFolder": "./config-sync/development"
+    },
+    "staging": {
+      "host": "https://server-staging.example.dev",
+      "token": "staging-token",
+      "distFolder": "./config-sync/staging"
+    },
+    "production": {
+      "host": "https://server-production.example.dev",
+      "token": "production-Token",
+      "distFolder": "./config-sync/production"
+    }
+  },
+  "alias": {
+    "dev": "development"
+  }
+}
+```
+
+How to use these configs in the terminal:
+```sh
+# with `env` param
+npx livingdocs-cli project-config:download --env development
+
+# in shorthand form
+npx livingdocs-cli project-config:download -e development
+
+# in shorthand form and also using an alias
+npx livingdocs-cli project-config:download -e dev
+```
+
+#### Multiple projects & environments
+
+`.livingdocs-cli` file in the root of your working directory:
+```json
+{
+  "projects": {
+    "projectA": {
+      "environments": {
+        "development": {
+          "host": "https://server-development.exampleA.dev",
+          "token": "dev-token",
+          "distFolder": "./sync-projectA/development"
+        },
+        "production": {
+          "host": "https://server-production.exampleA.dev",
+          "token": "production-Token",
+          "distFolder": "./sync-projectA/production"
+        }
+      }
+    },
+    "projectB": {
+      "environments": {
+        "development": {
+          "host": "https://server-development.exampleB.dev",
+          "token": "dev-token",
+          "distFolder": "./sync-projectB/development"
+        },
+        "production": {
+          "host": "https://server-production.exampleB.dev",
+          "token": "production-Token",
+          "distFolder": "./sync-projectB/production"
+        }
+      }
+    }
+  },
+
+  "alias": {
+    "dev": "development"
+  }
+}
+```
+
+How to use these configs in the terminal:
+```sh
+# # with `project` and `env` params
+npx livingdocs-cli project-config:download --project projectA --env development
+
+# in shorthand form
+npx livingdocs-cli project-config:download -p projectA -e development
+
+# in shorthand form and using an alias
+npx livingdocs-cli project-config:download -p projectA -e dev
+```

--- a/livingdocs-cli/cli-dotfile.md
+++ b/livingdocs-cli/cli-dotfile.md
@@ -5,7 +5,7 @@
 In case you are working with multiple projects and/or environments it becomes
 cumbersome to set tokens, hosts and other params.
 
-To make this easier you can set up a dotfile that allows you to pass
+To make the sync projects process easier you can set up a dotfile that allows you to pass
 `env` and `project` to all commands where this makes sense instead of
 using e.g. the `LI_TOKEN` environment variable.
 
@@ -42,6 +42,10 @@ using e.g. the `LI_TOKEN` environment variable.
   }
 }
 ```
+
+Note: it is recommended to add a production token with only
+read access. When publishing a new config you can
+supply a write token via `--token` argument.
 
 How to use these configs in the terminal:
 ```sh

--- a/livingdocs-cli/sync-configs.md
+++ b/livingdocs-cli/sync-configs.md
@@ -1,0 +1,96 @@
+# Sync project configs between projects
+
+## What are we doing here?
+
+In case you store your project configurations in the database you will need
+to make sure that both changes made in production as well as new changes added
+for new features all end up at the right time in all your environments.
+
+So here we describe one possible approach to sync project configurations
+between local, development, staging and production environments.
+
+
+#### Set up CLI environment variables
+
+For easier working with multiple projects and environments first set up
+a `.livingdocs-cli` dotfile: [Set up your cli dotfile](./cli-dotfile.md)
+
+
+## Commands you can use to sync configs
+
+#### Download project config
+
+Download:
+```sh
+npx livingdocs-cli project-config:download --format json --project projectA --env development
+```
+
+#### Publish changes
+
+```sh
+# plan update and verify only the expected properties are updated
+npx livingdocs-cli project-config:plan --project projectA --env development
+
+# if everything looks ok, do the update
+npx livingdocs-cli project-config:publish --project projectA --env development
+```
+
+#### Diffing two versions
+
+Here we can simply use `git diff --no-index` to use git to compare to
+files.
+
+```sh
+# --no-index diffs the two folders without regard to their current
+# status in git
+git diff --no-index sync-projectA/local sync-projectA/development
+```
+
+## Examples
+
+#### Full multi-project enterprise workflow example
+
+This workflow is for enterprise customers who also have a local setup
+of livingdocs on their machine.
+
+
+1. Download all configs:
+```sh
+npx livingdocs-cli project-config:download --format json -p projectA --env dev &&
+npx livingdocs-cli project-config:download --format json -p projectA --env staging &&
+npx livingdocs-cli project-config:download --format json -p projectA --env production
+
+npx livingdocs-cli project-config:download --format json -p projectB --env dev &&
+npx livingdocs-cli project-config:download --format json -p projectB --env staging &&
+npx livingdocs-cli project-config:download --format json -p projectB --env production
+```
+
+2. Commit these changes
+
+3. Download local configs (these usually have the latest changes)
+```sh
+npx livingdocs-cli project-config:download --format json -p projectA --env local
+npx livingdocs-cli project-config:download --format json -p projectB --env local
+```
+
+4. Compare configs (here just one example)
+```sh
+git diff --no-index sync-projectA/local sync-projectA/development
+```
+Note that some configs like renditions or preview urls are always different
+between environments.
+
+5. Make changes to config files
+
+6. Publish changed configs (also just one example)
+```sh
+# plan update and verify only the expected properties are updated
+npx livingdocs-cli project-config:plan -p projectA --env development
+
+# if everything looks ok, do the update
+npx livingdocs-cli project-config:publish -p projectA --env development
+```
+
+7. Discard `sync-projectA/local` and `sync-projectB/local`
+
+8. Commit the rest

--- a/livingdocs-cli/sync-configs.md
+++ b/livingdocs-cli/sync-configs.md
@@ -1,4 +1,4 @@
-# Sync project configs between projects
+# Sync project configs between environments
 
 ## What are we doing here?
 


### PR DESCRIPTION
## Changelog

- Add docs how to set up a `.livingdocs-cli` file
- Describe config sync process with the CLI
- Add those to the main navigation