### PR TITLE
feat(delivery links): add doc for delivery links to content type config example

### DIFF
--- a/reference-docs/server-configuration/content-type-config.md
+++ b/reference-docs/server-configuration/content-type-config.md
@@ -71,14 +71,21 @@ We plan to allow to move all layout options which are currently defined in the d
     },
 
     frontend: {
-      // link pattern for ld-editor publish panel to generate a link
-      // Available placeholders:
+      // One or multiple deliveryLinks are show in the publish panel
+      // They should point to your frontends
+      // url can be a pattern containing these placeholders:
       // :path
       // :routingPath
       // :id
       // :projectId
       // :slug
-      preview: 'http://localhost:9999/:slug',
+      deliveryLinks: [
+        {
+          url: 'http://localhost:9999/:slug',
+          icon: 'link-variant',
+          label: 'Publish link'
+        }
+      ]
 
       // link pattern for api access to that document
       // The same placeholders apply as for the preview


### PR DESCRIPTION
- add `deliveryLinks` example
- remove `frontend.preview` example