### PR TITLE
fix: improve text formatting documentation

### DIFF
--- a/reference-docs/editor-configuration/text-editing.md
+++ b/reference-docs/editor-configuration/text-editing.md
@@ -55,7 +55,7 @@ Example:
 ```js
  customElements: [{
       label: 'blue color',
-      handle: 'bluecolor',
+      handle: 'blue',
       // the tag which is set around the selection
       tagName: 'span',
       // the icon which will be displayed. Only existing icons in the editor can be used.

--- a/reference-docs/project-config/content_types.md
+++ b/reference-docs/project-config/content_types.md
@@ -357,7 +357,7 @@ Example:
 ```js
  customElements: [{
       label: 'blue color',
-      handle: 'bluecolor',
+      handle: 'blue',
       // the tag which is set around the selection
       tagName: 'span',
       // the icon which will be displayed. Only existing icons in the editor can be used.

--- a/reference-docs/project-config/editor_settings.md
+++ b/reference-docs/project-config/editor_settings.md
@@ -291,7 +291,7 @@ Extend the text formatting toolbar with custom configured elements. The elements
 ```js
  customElements: [{
       label: 'blue color',
-      handle: 'bluecolor',
+      handle: 'blue',
       // the tag which is set around the selection
       tagName: 'span',
       // the icon which will be displayed. Only existing icons in the editor can be used.


### PR DESCRIPTION
### Motivation
This has been reported from the ns-group:
```
Wenn der handle des Elements gleich wie der value ist. Wird im Popover korrekt angezeigt das blue color angewendet ist. Dieser Zusammenhang ist aber aus der Doku nicht ersichtlich...

customElements: [{
      label: 'blue color',
      handle: 'bluecolor', <-- popover only works correctly if handle === attributes.value
      // the tag which is set around the selection
      tagName: 'span',
      // the icon which will be displayed. Only existing icons in the editor can be used.
      icon: 'format-color-highlight',
      // the attributes which are set on the tag
      attributes: [{name: 'class', value: 'blue'}] <-- value needs to be equal to 'handle'
    }]
``` 

Sounds more like an bug to me, maybe really just documentation @meinradandermatt can check that?