### PR TITLE
deliveries: add an example of a deliveries config to the project config

### DIFF
--- a/reference-docs/editor-configuration/text-editing.md
+++ b/reference-docs/editor-configuration/text-editing.md
@@ -331,6 +331,8 @@ Exclude individual directives from the text counter (example component config):
 
 #### Options
 If you set the internal hosts as regex, you can define default behavior for internal and external links.
+If you configure `deliveries` in your [Project Config](reference-docs/project-config/README.md) (added in release-2020-12)
+links to these deliveries will be treated as internal links as well and you don't need to define the regex.
 ```js
 {
   links:{

--- a/reference-docs/project-config/README.md
+++ b/reference-docs/project-config/README.md
@@ -167,6 +167,32 @@ The project config is a huge JSON file with subproperties for things like conten
     dashboards: [],
     mediaLibrary: {}
   }
+
+  // Deliveries contains information about the delivery systems you operate
+  // added in release-2020-12
+  deliveries: [
+    {
+      handle: 'web',
+      label: 'Website',
+      isPrimary: true,
+      icon: 'book-open',
+      url: {
+        origin: 'https://example.com',
+        // possible patterns:, :path, :routingPath, :projectId, :slug, :id
+        pathPattern: '/article/:id'
+      }
+    },
+    {
+      handle: 'app',
+      label: 'App',
+      icon: 'rocket',
+      url: {
+        origin: 'https://example.com',
+        pathPattern: '/app/article/:id'
+      }
+    }
+  ]
+
 }
 ```
 
@@ -176,6 +202,7 @@ In a nutshell, the project configuration allows you to:
 * define contentTypes
 * define mediaTypes
 * define copy options
+* define the deliveries you operate per content-type
 * configure the push notifications feature
 * configure the multi-language feature
 * configure integrations


### PR DESCRIPTION
Related PRs:
  - https://github.com/livingdocsIO/livingdocs-server/pull/3150
  - https://github.com/livingdocsIO/livingdocs-editor/pull/3909
 
This adds an example of a `deliveries` config to the project config.
