### PR TITLE
doc(includesApi): fix examples

### DIFF
--- a/guides/twitter_include_embed.md
+++ b/guides/twitter_include_embed.md
@@ -50,9 +50,9 @@ liServer.features.register('custom-includes', require('app/includes'))
 // app/includes/index.js
 module.exports = async function (feature, server) {
   const includesApi = server.features.api('li-includes')
-  await includesApi.registerServices([
+  await includesApi.registerService(
     require('../../plugins/includes/tweet')
-  ])
+  )
 }
 
 // ../../plugins/includes/tweet.js

--- a/guides/youtube_include.md
+++ b/guides/youtube_include.md
@@ -43,9 +43,9 @@ module.exports = async function (feature, server) {
   const includesApi = server.features.api('li-includes')
 
   // register the include service
-  await includesApi.registerServices([
+  await includesApi.registerService(
     require('../../plugins/includes/youtubeService')
-  ])
+  )
 }
 
 // ../../plugins/includes/youtubeService.js

--- a/reference-docs/includes/article_and_list_includes.md
+++ b/reference-docs/includes/article_and_list_includes.md
@@ -59,9 +59,9 @@ In order for the editor to know which user interface to render for which `doc-in
 ```js
 module.exports = async function (feature, server) {
   const includesApi = server.features.api('li-includes')
-  await includesApi.registerServices([
+  await includesApi.registerService(
     require('../../plugins/includes/gallery-embed')
-  ])
+  )
 }
 ```
 
@@ -162,10 +162,10 @@ module.exports = async function (feature, server) {
   const includesApi = server.features.api('li-includes')
   const publicationApi = server.features.api('li-documents').publication
   const documentListsApi = server.features.api('li-document-lists')
-  await includesApi.registerServices([
+  await includesApi.registerService(
     // an example for the code in this include service is right below
     require('../../plugins/includes/list.js')(documentListsApi, publicationApi)
-  ])
+  )
 }
 ```
 

--- a/reference-docs/includes/server_customization.md
+++ b/reference-docs/includes/server_customization.md
@@ -72,11 +72,10 @@ Let's register an include renderer for the core include `embed-teaser`. Since ar
 ```js
 const includesApi = liServer.features.api('li-includes')
 
-await includesApi.registerServices([
+await includesApi.registerService(
   // registers the include rendering service
   require('./plugins/includes/embed-teaser.js')
-  require('./plugins/includes/twitter.js')
-])
+)
 ```
 
 `plugins/includes/embed-teaser.js`:


### PR DESCRIPTION
## Motivation

We don't expose any `includesApi.registerServices` function to register an array of services but only `includesApi.registerService` to register a single include service.

This PR fixes the examples accordingly.