### PR TITLE
chore(links): Fix broken service links

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -14,11 +14,11 @@ This short guide explains how to set up and use the service with your own design
 ### 2\) Create your own design
 
 * [Download](getting_started.md#download-project-config-from-service) the project config from the Livingdocs Service
-* Understand and modify the [project config](reference-docs/project_config/README.md)
+* Understand and modify the [project config](reference-docs/project-config/README.md)
   * modify the project settings
   * add contentTypes
   * define components and metadata in contentTypes
-  * define your design [design settings](reference-docs/project_config/design.md)
+  * define your design [design settings](reference-docs/project-config/design.md)
 * [Publish](getting_started.md#publish-a-project-config-to-the-service) your project config and the embedded design at the Livingdocs Service
 
 ### 3\) Administration

--- a/guides/access_rights.md
+++ b/guides/access_rights.md
@@ -16,7 +16,7 @@ So setting a role on a group gives users of this group certain scopes in the sys
 ## Available Scopes
 
 This lists all available scopes with their system identifiers.
-In the configuration you might find `scope` settings in some places, e.g. for the [sidePanelItems](../reference-docs/editor-configuration/editing-features.md#main-menu).
+In the configuration you might find `scope` settings in some places, e.g. for the [sidePanelItems](../reference-docs/project-config/editor_settings.md).
 
 Articles:
 

--- a/guides/add-custom-realtime-proofreading-dashboard.md
+++ b/guides/add-custom-realtime-proofreading-dashboard.md
@@ -30,7 +30,7 @@ metadata: [{
 ```
 
 References:
-- [How to customise a proofreading task](./add-custom-proofreading-task)
+- [How to customise a proofreading task](./add-custom-proofreading-task.md)
 - [How to configure a metadata field](../reference-docs/server-configuration/metadata)
 
 ### Add my-proofreading to elasticsearch
@@ -53,7 +53,7 @@ dashboards: [{
 ```
 
 References:
-- [How to configure custom dashboards](../reference-docs/editor-configuration/menu-and-dashboards)
+- [How to configure custom dashboards](../reference-docs/project-config/editor_settings.md#dashboards)
 
 ## 3) Add your custom dashboard to the menu
 
@@ -79,7 +79,7 @@ How to test it
 - go to the `My Proofreading` dashboard via the menu and look if your task is on the board
 
 References:
-- [How to add a custom dashboard entry](../reference-docs/editor-configuration/menu-and-dashboards)
+- [How to add a custom dashboard entry](../reference-docs/project-config/editor_settings.md#dashboards)
 
 
 ## 4) Customise a card on the dashboard

--- a/guides/add_customizations.md
+++ b/guides/add_customizations.md
@@ -11,7 +11,7 @@ This document gives an overview of how to register custom features without going
 
 A custom server feature can contain any code you like. Common examples are bridges to third-party APIs or import features that import documents from some other source like an old legacy CMS.
 
-The explanations here only refer to customizations that need coding. Other behavior can be customized using the [JSON configuration files](../reference-docs/server-configuration/config.md).
+The explanations here only refer to customizations that need coding. Other behavior can be customized using the [JSON configuration files](../reference-docs/project-config/settings.md).
 
 In the server you will normally have an `app/server.js` file add new features. The content looks something like this:
 ```js
@@ -70,7 +70,7 @@ The code customizations in the Livingdocs editor (user interface) are restricted
 - custom Angular components for metadata fields
 - .. or [custom model classes](../reference-docs/editor-configuration/metadata.html) for existing metadata fields
 - custom Angular components for doc-include sidebar user interfaces
-- custom [Dashboard filters](../reference-docs/editor-configuration/menu-and-dashboards.md)
+- custom [Dashboard filters](../reference-docs/project-config/editor_settings.md#dashboards)
 - custom Dahboard item (a single item in the articles dashboard)
 - custom Embed components (the core contains Iframes and Tweets)
 - custom Iframely metadata extractors

--- a/guides/create_designs.md
+++ b/guides/create_designs.md
@@ -1,7 +1,7 @@
 
 # Livingdocs Design and Components
 
-The [boilerplate server](https://github.com/livingdocsIO/livingdocs-server-boilerplate) has an embedded design. The entry point for your project config is in "setup/seeding.js". This file requires a complete [project config](../project-config/README.md) that also contains the two relevant design configs `design_settings.js` and the `components` folder.
+The [boilerplate server](https://github.com/livingdocsIO/livingdocs-server-boilerplate) has an embedded design. The entry point for your project config is in "setup/seeding.js". This file requires a complete [project config](../reference-docs/project-config/README.md) that also contains the two relevant design configs `design_settings.js` and the `components` folder.
 
 _Good to know_ you might come across the notion of a "reference design". Reference designs are basically the same as embedded designs, but live externally, e.g. on an S3 bucket and are referenced in a project. The downside of reference designs is that they can not be customized in the context of a single project.
 
@@ -43,7 +43,7 @@ module.exports = {
 
 Lets recap what we have.
 Every component defines a `name` to reference it in the system, a `label` and `iconUrl` for display and an `html` containing the markup.
-The HTML itself contains declarative directives that are prepended with `doc-`, in our example `doc-editable` and `doc-image` ([learn all about directives](../project-config/design.md#components)). Those tell the Livingdocs editor where the users can edit content.
+The HTML itself contains declarative directives that are prepended with `doc-`, in our example `doc-editable` and `doc-image` ([learn all about directives](../reference-docs/project-config/design.md#components)). Those tell the Livingdocs editor where the users can edit content.
 The directives themselves can contain configuration, referenced in the `directives` property. In our example we tell the Livingdocs editor that we want to give the image preset ratios of '16:9' and '4:3'.
 
 To get the component displayed in the editor you need to do 3 more things:
@@ -104,4 +104,4 @@ This is the publication screen for your project config. Every change is shown in
 If you're fine with your changes, scroll to the bottom and click "Publish Changes".
 Navigate to any article and in the "Insert" sidebar the header will now be in first place.
 
-Congratulations, you've taken your first steps in a Livingdocs Design! To learn more about designs, refer to [the design reference documentation](../project-config/design.md).
+Congratulations, you've taken your first steps in a Livingdocs Design! To learn more about designs, refer to [the design reference documentation](../reference-docs/project-config/design.md).

--- a/guides/github-login.md
+++ b/guides/github-login.md
@@ -19,7 +19,7 @@ This flow assumes that the users from the SSO provider haven been created within
 
 ### Enabling an authentication route in the editor
 
-On the login screen of the Livingdocs editor you want a way to actually use your third-party SSO login. You can configure it like this in the [editor configuration](../reference-docs/editor-configuration/editing-features.html):
+On the login screen of the Livingdocs editor you want a way to actually use your third-party SSO login. You can configure it like this in the [editor configuration](../reference-docs/project-config/editor_settings.md):
 ```
 auth: {
   providers: [{

--- a/guides/hugo-dnd.md
+++ b/guides/hugo-dnd.md
@@ -3,7 +3,7 @@
 ## Basic Configuration
 
 To enable dragging both images and documents from _huGO+_ into livingdocs you first need to configure `hugo.resource`
-in the [server configuration](../reference-docs/server-configuration/config.md)
+in the [server configuration](../reference-docs/project-config/README.md)
 
 
 ## Image Drag and Drop
@@ -11,7 +11,7 @@ in the [server configuration](../reference-docs/server-configuration/config.md)
 Images can be dragged onto a livingdocs document directly from _huGO+_ after the basic configuration is set up.
 
 Note: you can restrict from which sources images can be uploaded, e.g. you could allow only uploads from _huGO+_.
-See [Image Source Policy](../reference-docs/editor-configuration/image-source-policy.md)
+See [Image Source Policy](../reference-docs/project-config/content_types.md#image-source-policy)
 
 
 ## Document Drag and Drop

--- a/guides/image-services.md
+++ b/guides/image-services.md
@@ -29,7 +29,7 @@ You can configure your own image storage using the following configuration:
 ```
 
 This will route image upload requests from Livingdocs to your chosen URL instead of S3.
-For details please see the reference documentation for the [server configuration](../../reference-docs/server-configuration/config.md)
+For details please see the reference documentation for the [server configuration](../reference-docs/project-config/README.md)
 
 ### Delivery
 

--- a/guides/push_notifications.md
+++ b/guides/push_notifications.md
@@ -19,9 +19,9 @@ The resulting feature looks as follows.
 ## Enable push notifications
 
 To enable push notifications you need to do 3 things:
-1. setup the firebase config in your [server configuration](../reference-docs/server-configuration/config.md#push-notifications), you will need to create a Google firebase key for this
-2. in every channel that should support push notifications, [configure the required metadata field](../reference-docs/project-config/content_types.md#push-notifications)
-3. in every channel that should support push notifications, [configure your topics](../reference-docs/project-config/content_types.md#push-notifications)
+1. setup the firebase config in your [server configuration](../reference-docs/project-config/README.md), you will need to create a Google firebase key for this
+2. in every channel that should support push notifications, [configure the required metadata field](../reference-docs/project-config/content_types.md#enable-push-notifications-for-a-contenttype)
+3. in every channel that should support push notifications, [configure your topics](../reference-docs/project-config/content_types.md#enable-push-notifications-for-a-contenttype)
 4. setup the push notifications field in your elasticsearch mapping
 
 The [livingdocs server boilerplate](https://github.com/livingdocsIO/livingdocs-server-boilerplate) has commented out sections for all three things so you can check there.
@@ -66,9 +66,9 @@ After doing those three things, push notifications are enabled and you can see t
 ## Add a custom dashboard item
 
 You need to do 3 things to have your custom dashboard item that shows push notification information:
-1. [whitelist the push notification metadata for use in the dashboard](../reference-docs/server-configuration/config.md#search)
+1. [whitelist the push notification metadata for use in the dashboard](../reference-docs/project-config/editor_settings.md#example-dashboard)
 2. create an angular component for the dashboard item
-3. [configure the angular component in the editor](../reference-docs/editor-configuration/editing-features.md#dashboard)
+3. [configure the angular component in the editor](../reference-docs/project-config/editor_settings.md#dashboard)
 
 Below is a sample implementation for (2).
 

--- a/guides/setup_multilanguage.md
+++ b/guides/setup_multilanguage.md
@@ -84,7 +84,7 @@ The details about adding a new metadata field can be seen in the [metadata examp
 ### Dashboard
 
 As soon as we have the multi-language feature configured, the dashboard will show a new column `languages` in the search results.
-In order for the dashboard to have the required metadata, you will need to configure the [`documentsMetadataFields`](../reference-docs/server-configuration/config.md) in the server config to include your metadata property. You need to use the metadata property name here. In our example from before this would be:
+In order for the dashboard to have the required metadata, you will need to configure the [`documentsMetadataFields`](../reference-docs/project-config/README.md) in the server config to include your metadata property. You need to use the metadata property name here. In our example from before this would be:
 ```js
 {
   search: {
@@ -99,7 +99,7 @@ Note: if you did your [own dashboard item](./push_notifications.md#add-a-custom-
 
 ## Editor
 
-The editor side is relatively easy to configure. You only need to add the provided language [core filter](../reference-docs/editor-configuration/menu-and-dashboards.md) to your dashboard so that you are able to filter documents by language. This is done in the editor environment config file.
+The editor side is relatively easy to configure. You only need to add the provided language [core filter](../reference-docs/project-config/editor_settings.md#dashboards) to your dashboard so that you are able to filter documents by language. This is done in the editor environment config file.
 
 ```js
 {

--- a/guides/setup_windows.md
+++ b/guides/setup_windows.md
@@ -20,4 +20,4 @@ https://docs.microsoft.com/en-us/windows/wsl/install-win10
 - Run all the npm and node steps in the bash from linux
   - As information when you start the editor you have to type manually the url http://localhost:9000 
 - Run all the docker commands in powershell
-- Proceed with the [getting started](./getting-started-with-local-development)
+- Proceed with the [getting started](./getting-started-with-local-development.md)

--- a/guides/validate_tasks.md
+++ b/guides/validate_tasks.md
@@ -36,7 +36,7 @@ app: {
 }
 ```
 
-Above we see the configuration of our custom task in the editor. There is nothing special here. The metadata entry in elasticsearch for the review task already exists in the boilerplate so you don't need to do anything in this regard. If you have a different task name or don't work with the boilerplate, see [here](../reference-docs/editor-configuration/editing-features.md#tasks) for what to do in elastic.
+Above we see the configuration of our custom task in the editor. There is nothing special here. The metadata entry in elasticsearch for the review task already exists in the boilerplate so you don't need to do anything in this regard. If you have a different task name or don't work with the boilerplate, see [here](../reference-docs/project-config/editor_settings.md#dashboards) for what to do in elastic.
 
 ## Server plugin
 

--- a/reference-docs/includes/embed_and_list.md
+++ b/reference-docs/includes/embed_and_list.md
@@ -50,7 +50,7 @@ Lets see an example component in a Livingdocs design.
 ```
 
 First note that the component makes use of the `embed-teaser` service for the `doc-include` directive `gallery-embed`. It instances the service. In the `defaultParams` we pass a `layout` to the server-side rendering.
-The most important thing is the configuration in `config.search`. The configuration is equivalent to the one of the dashboard search. Please see [here](../editor-configuration/menu-and-dashboards.md) for all available options. The configuration in the example above allows the user to select available filters for `documentState` (e.g. published, etc.) and adds the hidden queries to only show articles (no pages) and of the articles only the subset of image galleries. This seems to be a sane default for an image gallery search modal.
+The most important thing is the configuration in `config.search`. The configuration is equivalent to the one of the dashboard search. Please see [here](../project-config/editor_settings.md#user-menu) for all available options. The configuration in the example above allows the user to select available filters for `documentState` (e.g. published, etc.) and adds the hidden queries to only show articles (no pages) and of the articles only the subset of image galleries. This seems to be a sane default for an image gallery search modal.
 
 #### Server-side registration
 
@@ -90,7 +90,7 @@ module.exports = {
   }
 ```
 
-The above code snippet assumes you are inside a custom feature. See [here](../../guides/add_customizations.html#server) for how to register a custom feature.
+The above code snippet assumes you are inside a custom feature. See [here](../../guides/add_customizations.md#server) for how to register a custom feature.
 The `name` of the `doc-include` to register must match the service name you used in the design definition. In the case of the article embed, the `name` must be `embed-teaser`.
 The first key we have, `uiComponents`, defines a list of ui components that are rendered in the sidebar of the editor for the given `doc-include`. We will come back to all the available options when describing [how to do custom editor user interfaces](./editor_customization.md). For now just note that we register 2 Angular components: `liEmbedTeaserIncludeModal` and `liEmbedTeaserLink`. Those are predefined in the core and the names must exactly match. (note: if you don't want a link to the embedded article in the sidebar, just leave the `liEmbedTeaserLink` entry away)
 The second key `rendering` defines how your doc-include should be rendered. We will come back to the remote options later. For now take note of the function method that allows you to define a function that returns the rendering of the doc-include as an HTML string.
@@ -187,7 +187,7 @@ module.exports = {
   }
 ```
 
-The above code snippet again assumes you are inside a custom feature. See [here](../../guides/add_customizations.html#server) for how to register a custom feature.
+The above code snippet again assumes you are inside a custom feature. See [here](../../guides/add_customizations.md#server) for how to register a custom feature.
 The `name` of the `doc-include` to register must match the service name you used in the design definition. In the case of the manual list, the `name` must be `list`.
 The first key we have `uiComponents` defines a list of ui components that are rendered in the sidebar of the editor for the given `doc-include`. For the list example we register the predefined component `liManualList`. The name must much exactly.
 The second key `rendering` defines how your doc-include should be rendered. The options and method are equivalent to the `embed-teaser` case.

--- a/reference-docs/project-config/content_types.md
+++ b/reference-docs/project-config/content_types.md
@@ -110,7 +110,7 @@ NOTE: the default content only gets applied when a document is created manually,
 
 The default content is simply a (valid) Livingdocs JSON applying to your design. We advise you to use the UI in the "Project Setup" for adapting the default content.
 
-One useful property on components within the default content is the `position: fixed` property. It allows to fix a component in place, useful, e.g. for headers. [Read more](../editor-configuration/editing-features.md#pin-components)
+One useful property on components within the default content is the `position: fixed` property. It allows to fix a component in place, useful, e.g. for headers.
 
 ## Editor Wrapper
 
@@ -270,7 +270,7 @@ The schema is as follows:
   })
 ```
 
-Apart from the general settings (`renderSettings`) you define an entry for each teaser (`teasers`) giving it the Livingdocs component (from the design) that should be used for rendering as well as a mapping of metadata values to component directives. See our guide on [teaser previews](../server-configuration/teaser-preview-config.md) for more details.
+Apart from the general settings (`renderSettings`) you define an entry for each teaser (`teasers`) giving it the Livingdocs component (from the design) that should be used for rendering as well as a mapping of metadata values to component directives. See our guide on [teaser previews](../includes/embed_and_list.md#embed-teaser) for more details.
 
 ## Desk-Net 
 *has UI support*
@@ -327,7 +327,7 @@ metadata: [{
 }]
 ```
 
-With this in place you can set the channel configuration for your push notification topics \(see example config above\) and the firebase configuration in the [server config](../server-configuration/config.md#push-notifications).
+With this in place you can set the channel configuration for your push notification topics \(see example config above\) and the firebase configuration in the [server config](./README.md).
 
 ## Text Formatting
 


### PR DESCRIPTION
More of the same link fixes as in PR #347, but for the service branch this time. I couldn't fix as many links as I managed in the other PR as there seems to be some missing documentation regarding Elasticsearch indexing, webhooks, and metadata.