### PR TITLE
doc(teasers): add docs for paramsSchema li-reference and paramsSchemaExtension teaser includes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -94,6 +94,7 @@
   * [Desk-Net Integration (Planning)](guides/desknet-integration.md)
 * Includes / Embeds
   * [Configure Includes: Article Embed and List](reference-docs/includes/article_and_list_includes.md)
+  * [Article Teaser (with release-2021-03)](reference-docs/includes/article_teasers_.md)
   * [Includes: Add an Twitter Include](guides/twitter_include_embed.md)
   * [Includes: Add a Youtube Include](guides/youtube_include.md)
   * [Includes: Embedded Documents](guides/embedded_documents.md)

--- a/guides/article_teasers.md
+++ b/guides/article_teasers.md
@@ -1,0 +1,64 @@
+# Article Teasers
+
+With `release-2021-03` a simpler way to setup teasers is introduced. It is based on [Includes](reference-docs/includes/intro.md) and the possiblity to define the UI with a `paramsSchema`.
+
+This guide assumes that you are familiar with the possibilities to register an Include Service and how to use it in a Component.
+
+## Include Service
+Here is an example includes configuration to consider for the editable teaser usecase:
+```js
+{
+  name: 'teaser',
+  paramsSchema: [
+    // this will render a UI in the document editing sidebar to let the User select a document with
+    // the contentType `regular` to link to.
+    {
+      handle: 'article',
+      type: 'li-reference',
+      config: {
+        referenceType: 'document',
+      },
+      ui: {
+        label: 'Teaser'
+      }
+    }
+  ],
+  rendering: {
+    type: 'function',
+    render (params, options) {
+      // params.article.reference.id contains the id of the linked document
+      // you want to render the teaser here. Either as HTML or use the possibility of Embedded Documents
+      return params.article.reference.id
+    }
+  }
+}
+```
+
+## Teaser Component
+```js
+{
+  name: 'teaser-include',
+  label: 'Teaser',
+  iconUrl: 'URL to an SVG icon',
+  directives: [{
+    name: 'teaser',
+    type: 'include',
+    service: 'teaser', // refer to the include service handle
+    paramsSchemaExtension: [ // extend the config for li-reference type input
+      {
+        name: 'article', // refer to the handle of the 
+        config: {
+          // configure base filters for the article search modal
+          contentType: ['regular'], // only document of contentType 'regular'
+          published: true // only published documents
+        }
+      }
+    ]
+  }],
+  html: `
+    <div doc-include="teaser">
+      <div>Link an Article</div>
+    </div>
+  `
+}
+```

--- a/guides/embedded_documents.md
+++ b/guides/embedded_documents.md
@@ -24,22 +24,20 @@ An example of an includes return value:
       link: 'https://example.com'
     }
   }
+}
 ```
 
-Here is an includes configuration you would want to consider for the editable teaser usecase:
+Here is an example includes configuration to consider for the editable teaser usecase:
 ```js
 {
   name: 'editable-teaser',
   paramsSchema: [
-    // this will render a UI in the document editing sidebar to let the User select a document with
-    // the contentType `regular` to link to.
+    // this will render a UI in the document editing sidebar to let the User select a document
     {
       handle: 'article',
       type: 'li-reference',
       config: {
         referenceType: 'document',
-        documentType: 'article',
-        contentType: ['regular']
       },
       ui: {
         label: 'Teaser'
@@ -54,6 +52,36 @@ Here is an includes configuration you would want to consider for the editable te
   }
 }
 ```
+
+This is how your Teaser Component looks like in this case:
+```js
+{
+  name: 'teaser-include',
+  label: 'Teaser',
+  iconUrl: 'URL to an SVG icon',
+  directives: [{
+    name: 'teaser',
+    type: 'include',
+    service: 'editable-teaser',
+    paramsSchemaExtension: [ // <- added with release-2020-03
+      {
+        name: 'article',
+        config: {
+          // configure base filters for the article search modal
+          contentType: ['regular'], // only document of contentType 'regular'
+          published: true // only published documents
+        }
+      }
+    ]
+  }],
+  html: `
+    <div doc-include="teaser">
+      <div>Link an Article</div>
+    </div>
+  `
+}
+```
+
 
 ## Caveats
 - `editableContent` has no effect when more than one component is returned.

--- a/reference-docs/includes/editor_customization.md
+++ b/reference-docs/includes/editor_customization.md
@@ -7,6 +7,11 @@ The possibility to use AngularJS will be phased out in the future. If you are do
 
 In order to actually render content, you need to configure the server to do so, [see here](./server_customization.md) how that works.
 
+
+### Include User Interface with paramsSchema
+This is the most simple way to render a UI for the include. It doesn't need any code in the editor.
+[See here](./server_customization.md#generated-sidebar) for an example.
+
 ### Custom Include User Interface with Vue
 Here is an example of an include User Interface Vue Component:
 ```


### PR DESCRIPTION
Relations:
  - Related PR's:
    - Server: https://github.com/livingdocsIO/livingdocs-server/pull/3385
    - Editor: https://github.com/livingdocsIO/livingdocs-editor/pull/4152
    - Framework: https://github.com/livingdocsIO/livingdocs-framework/pull/533