### PR TITLE
Add access hook doc

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -77,11 +77,13 @@
 * [Register a Custom Server Feature](guides/add_customizations.md)
 * [Register a Custom Display Filter](guides/register_custom_dashboard_filters_.md)
 * [Copy documents between types](guides/document_copy.md)
-* [Assign Access Rights](guides/access_rights.md)
 * [Implement Single Sign-On](guides/github-login.md)
 * [Use Push Notifications and Custom Dashboard Item](guides/push_notifications.md)
 * [Enable Multi-Language Support](guides/setup_multilanguage.md)
 * [Author Management](guides/prefill-author.md)
+* Access
+  * [Assign Access Rights](guides/access_rights.md)
+  * [Access Hooks](guides/access_hooks.md)
 * Imports
   * [DPA Import](guides/dpa-import.md)
   * [Import Legacy System Documents](guides/import-legacy-system-documents.md)

--- a/guides/access_hooks.md
+++ b/guides/access_hooks.md
@@ -1,0 +1,71 @@
+# Access Hooks
+
+The access hook feature allows to register a function on the server that intercepts the document modifications before the document gets saved to the database. It should only be used for access control, **not** to mutate the document.
+
+A hook can return a permission error (with a 403 `status` property) which is consumed by the editor.
+
+## Alpha Stage
+
+The implementation of the access hooks is in an alpha stage and could change in the future. We might introduce policies that will replace the hooks at a later step. So please make sure you don't implement complex logic using the hooks.
+
+## Example
+
+Here you see a simple example which rejects a document update when the title is set to 'examplePermissionError'.
+
+```js
+// server
+liServer.registerInitializedHook(async () => {
+  const accessControlApi = server.features.api('li-access-control')
+  accessControlApi.registerHook(async ({action, nextDocument}) => {
+    if (action === 'document.update') {
+      if (nextDocument.metadata.title === 'examplePermissionError') {
+        return accessControlApi.metadataPermissionError({
+          message: 'Title cannot be "examplePermissionError"',
+          metadataProperty: 'title'
+        })
+      }
+    }
+  })
+})
+```
+
+
+# Advanced Example
+
+In this example we only allow the server admin (which has userId = 1) to update a document which has the category 'financialReport'. It's only a showcase to get a feeling what you could do.
+
+```js
+const accessControlApi = server.features.api('li-access-control')
+
+// Hook parameters
+// ---------------
+// action          - document.create / document.update / document.get / document.delete / document.publish / document.unpublish
+// projectId
+// userId
+// newDocument     - only available on action = 'document.create'
+// documentVersion - stored document
+// nextDocument    - document update which will be stored when the access check is valid
+//
+// RETURN
+//   true or undefined or null - the document modification is allowed
+//   throw an error            - the document modification will be rejected, the error will be showed in the editor
+accessControlApi.registerHook(function ({action, projectId, userId, newDocument, documentVersion, nextDocument}) {
+  switch (action) {
+    case 'document.create': return true
+    case 'document.update': return canUpdate(documentVersion, userId)
+    case 'document.get': return true
+    case 'document.delete': return canUpdate(documentVersion, userId)
+    case 'document.publish': return canUpdate(documentVersion, userId)
+    case 'document.unpublish': return canUpdate(documentVersion, userId)
+  }
+})
+
+function canUpdate (documentVersion, userId) {
+  const hasFinancialReport = documentVersion.getMetadata().category === 'financialReport')
+  if (hasFinancialReport && userId !== 1) {
+   throw accessControlApi.permissionError(
+    'No user except the admin is allowed to edit documents in the category financialReport'
+   )
+  }
+}
+```


### PR DESCRIPTION
I just documented the current alpha state. If we change that in the future, we can update the documentation and break the API.

Original PR: https://github.com/livingdocsIO/livingdocs-server/pull/2445
Original Specification (outdated): https://github.com/livingdocsIO/livingdocs-planning/issues/2664 
Related Topic: ABAC (Access Control) - https://github.com/livingdocsIO/livingdocs-server/pull/2473